### PR TITLE
aws: Route53 + register SSL/TLS certs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 # AWS Account settings
-AWS_ACCOUNT-ID="add your AWS account ID"
+AWS_ACCOUNT_ID="add your AWS account ID"
 AWS_REGION="set your default region"
 
 # YOUR REGISTERED DOMAIN - CloudFront/Route53 Website settings

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,8 @@
+# AWS Account settings
+AWS_ACCOUNT-ID="add your AWS account ID"
+AWS_REGION="set your default region"
+
+# YOUR REGISTERED DOMAIN - CloudFront/Route53 Website settings
+# For this example your site will be deployed to aws.example.com
+APEX_DOMAIN="example.com"
+SUBDOMAIN="aws"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,3 +6,6 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# CDK Route 53 and ACM config
+cdk.context.json

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,9 @@ new BedrockAIStack(app, "BedrockAIStack", {
   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
+  env: {
+    account: `${process.env.AWS_ACCOUNT_ID}`,
+    region: `${process.env.AWS_REGION}`,
+  },
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,20 +1,17 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
 import { BedrockAIStack } from "./cdk-stacks";
+import { getAppEnvConfig } from "./helpers";
+
+const config = getAppEnvConfig();
 
 const app = new cdk.App();
 new BedrockAIStack(app, "BedrockAIStack", {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
+  /**
+   * For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+   */
   env: {
-    account: `${process.env.AWS_ACCOUNT_ID}`,
-    region: `${process.env.AWS_REGION}`,
+    account: config.awsAccountId,
+    region: config.awsRegion,
   },
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/backend/src/helpers/IAppEnvTypes.ts
+++ b/backend/src/helpers/IAppEnvTypes.ts
@@ -1,0 +1,7 @@
+export type IAppEnvTypes = {
+  awsAccountId: string;
+  awsRegion: string;
+  apexDomain: string;
+  subDomain: string;
+  fullUrl: string;
+};

--- a/backend/src/helpers/getAppEnvConfig.ts
+++ b/backend/src/helpers/getAppEnvConfig.ts
@@ -1,0 +1,30 @@
+import * as dotenv from "dotenv";
+import { IAppEnvTypes } from "./IAppEnvTypes";
+
+export const getAppEnvConfig = (): IAppEnvTypes => {
+  dotenv.config({ path: "../.env" });
+  const { AWS_ACCOUNT_ID, AWS_REGION, APEX_DOMAIN, SUBDOMAIN } = process.env;
+
+  // Check if environment variables exist
+  if (!AWS_ACCOUNT_ID) {
+    throw new Error("AWS_ACCOUNT_ID is not set.  Cannot deploy app to AWS.");
+  }
+  if (!AWS_REGION) {
+    throw new Error("AWS_REGION is not set.  Cannot deploy app to AWS.");
+  }
+  if (!APEX_DOMAIN) {
+    throw new Error("APEX_DOMAIN is not set.  Cannot deploy app to AWS.");
+  }
+  if (!SUBDOMAIN) {
+    throw new Error("SUBDOMAIN is not set.  Cannot deploy app to AWS.");
+  }
+
+  // create a full URL from SUBDOMAIN + APEX_DOMAIN
+  return {
+    awsAccountId: AWS_ACCOUNT_ID,
+    awsRegion: AWS_REGION,
+    apexDomain: APEX_DOMAIN,
+    subDomain: SUBDOMAIN,
+    fullUrl: `${SUBDOMAIN}.${APEX_DOMAIN}`,
+  };
+};

--- a/backend/src/helpers/index.ts
+++ b/backend/src/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from "./IAppEnvTypes";
+export * from "./getAppEnvConfig";


### PR DESCRIPTION
# AWS Route53 + register SSL/TLS certs

- create `.env.template` for Route 53 config
- create `.env.template` for ACM config
- deploy app to custom domain (in addition to CloudFront public ip)
